### PR TITLE
Fixes to make Resource Agents work on different cluster stacks

### DIFF
--- a/SAPHana/SAPHana
+++ b/SAPHana/SAPHana
@@ -167,8 +167,8 @@ The resource agent uses the following four interfaces provided by SAP:
 4. hdbsql / systemReplicationStatus
    Interface is SQL query into HANA (system replication table).  The hdbsql query will be replaced by a python script 
    "systemReplicationStatus.py" in SAP HANA SPS8 or 9.
-   As long as wee need to use hdbsql you need to setup secure store users for linux user root to be able to
-   access the SAP HANA database. You need to configure a secure store user key "SLEHALOC" which can connect the SAP
+   As long as we need to use hdbsql you need to setup secure store users for linux user root to be able to
+   access the SAP HANA database. You need to configure a secure store user key "SLEHALOC"/"RHELHALOC" which can connect the SAP
    HANA database: 
 
 5. saphostctrl
@@ -766,13 +766,25 @@ function analyze_hana_sync_status()
 {
     super_ocf_log info "FLOW $FUNCNAME ($*)"
     local hana_sync_status="" what_does_the_chamelion_say=""
-    local secUser="slehaLoc"
     local rc=0
     local sqlrc=0
     local query_state='select distinct REPLICATION_STATUS from SYS.M_SERVICE_REPLICATION'
     local query_secondaries='select distinct  SECONDARY_HOST from SYS.M_SERVICE_REPLICATION'
     local query_failed_secondaries="select distinct SECONDARY_HOST from SYS.M_SERVICE_REPLICATION  where SECONDARY_SITE_NAME = (select distinct  SECONDARY_SITE_NAME from SYS.M_SERVICE_REPLICATION WHERE REPLICATION_STATUS != 'ACTIVE')"
     local all_cluster_hosts all_secondary_hosts all_broken_secondaries
+    # TODO: PRIO4: remove check_secstore_users later
+    check_secstore_users SLEHALOC; chkusr=$?
+    if [ $chkusr -ne 0 ]; then
+         check_secstore_users RHELHALOC; chkusr=$?
+         if [ $chkusr -ne 0 ]; then
+              super_ocf_log err  "ACT: Secure store users are missing (see best practice manual how to setup the users)"
+              rc=$OCF_ERR_CONFIGURED
+         else
+             secUser="RHELHALOC"
+         fi
+    else
+         secUser="SLEHALOC"
+    fi
     hana_sync_status=$(timeout 60 $DIR_EXECUTABLE/hdbsql -a -x -U $secUser  $query_state); sqlrc=$?
     hana_sync_status=$(echo $hana_sync_status | dequote)
     super_ocf_log debug "DBG: hdbsql rc=$sqlrc hana_sync_status=\"$hana_sync_status\""
@@ -1459,8 +1471,20 @@ function saphana_start_clone() {
     # TODO: PRIO4: remove check_secstore_users later
     check_secstore_users SLEHALOC; chkusr=$?
     if [ $chkusr -ne 0 ]; then
-         super_ocf_log err  "ACT: Secure store users are missing (see best practice manual how to setup the users)"
-         rc=$OCF_ERR_CONFIGURED
+         check_secstore_users RHELHALOC; chkusr=$?
+         if [ $chkusr -ne 0 ]; then
+              super_ocf_log err  "ACT: Secure store users are missing (see best practice manual how to setup the users)"
+              rc=$OCF_ERR_CONFIGURED
+         else
+             set_hana_attribute ${HOSTNAME} "DEMOTED" ${ATTR_NAME_HANA_CLONE_STATE[@]}
+             check_for_primary; primary_status=$?
+             if [ $primary_status -eq $HANA_STATE_PRIMARY ]; then
+                 saphana_start_primary; rc=$?
+             else
+                 saphana_start_secondary; rc=$?
+                 lpa_set_lpt  30
+             fi
+         fi
     else
         set_hana_attribute ${HOSTNAME} "DEMOTED" ${ATTR_NAME_HANA_CLONE_STATE[@]}
         check_for_primary; primary_status=$?
@@ -1939,7 +1963,6 @@ SAPCONTROL=""
 DIR_PROFILE=""
 SAPSTARTPROFILE=""
 SAPHanaFilter="${OCF_RESKEY_SAPHanaFilter:-ra-act-dec-lpa}"
-
 
 if [ $# -ne 1 ]
 then

--- a/SAPHana/SAPHana
+++ b/SAPHana/SAPHana
@@ -292,7 +292,10 @@ function remoteHost2remoteNode()
     local remoteHost="$1"
     local remoteNode=""
     local rc=1
-    clusterNodes=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}))
+    case $(crm_attribute --type crm_config --name cluster-infrastructure -q) in    
+       *openais* ) clusterNodes=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}));;
+       *cman*    ) clusterNodes=($(crm_node -l | awk '{for (i=1; i<=NF; i++) { if ($i != me) { print $i }}}' me=${HOSTNAME}));;
+    esac
     for cl in ${clusterNodes[@]}; do
         vHost=$(get_hana_attribute $cl  ${ATTR_NAME_HANA_VHOST[@]})
         if [ "$vHost" = "$remoteHost" ]; then # we found the correct node
@@ -559,7 +562,10 @@ function saphana_init() {
     #
     remoteHost=$(get_hana_attribute ${HOSTNAME} ${ATTR_NAME_HANA_REMOTEHOST[@]});
     if [ -z "$remoteHost" ]; then
-       remoteHosts=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}))
+       case $(crm_attribute --type crm_config --name cluster-infrastructure -q) in
+          *openais* ) remoteHosts=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}));;
+          *cman*    ) remoteHosts=($(crm_node -l | awk '{for (i=1; i<=NF; i++) { if ($i != me) { print $i }}}' me=${HOSTNAME}));;
+       esac
        if [ ${#remoteHosts[@]} -eq 1 ]; then # we are a 2 node cluster, lets assume the other is the remote-host
           remoteHost=${remoteHosts[0]}
           remoteNode=$remoteHost
@@ -807,7 +813,10 @@ function analyze_hana_sync_status()
                 # DONE: PRIO1: We should NOT set SFAIL, if HDB is exactly broken now
                 #       When HDB breaks during monitor this could prevent a prositive remote failover
                 super_ocf_log warn "ACT: Was not able to fetch HANA SYNC STATUS - set sync status to SFAIL for ALL OTHER cluster hosts"
-                all_cluster_hosts=$(crm_node -Q -l -A | awk '($3 == "member") && ($2 != lh)  { print $2 }' lh=${HOSTNAME})
+                case $(crm_attribute --type crm_config --name cluster-infrastructure -q) in
+                   *openais* ) all_cluster_hosts=$(crm_node -Q -l -A | awk '($3 == "member") && ($2 != lh)  { print $2 }' lh=${HOSTNAME});;
+                   *cman*    ) all_cluster_hosts=$(crm_node -l | awk '{for (i=1; i<=NF; i++) { if ($i != me) { print $i }}}' me=${HOSTNAME});;
+                esac
                 for n in $all_cluster_hosts; do
                     set_hana_attribute "$n" "SFAIL" ${ATTR_NAME_HANA_SYNC_STATUS[@]}
                 done
@@ -1109,7 +1118,10 @@ check_for_primary_master()
     #
     # get actual list of cluster members
     # 
-    otherHosts=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}))
+    case $(crm_attribute --type crm_config --name cluster-infrastructure -q) in
+       *openais* ) otherHosts=($(crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}' me=${HOSTNAME}));;
+       *cman*    ) otherHosts=($(crm_node -l | awk '{for (i=1; i<=NF; i++) { if ($i != me) { print $i }}}' me=${HOSTNAME}));;
+    esac
     if [ -n "$otherHosts" ]; then
         for ch in ${otherHosts[@]}; do
             if [ $rc -eq 1 ]; then

--- a/SAPHana/SAPHanaTopology
+++ b/SAPHana/SAPHanaTopology
@@ -655,7 +655,12 @@ function sht_monitor_clone() {
     case "$hanaPrim" in
        P ) ;;
        S ) # only secondary may propargate its sync status
-        for n in $(crm_node -l | awk '/member/ {print $2}'); do
+        case $(crm_attribute --type crm_config --name cluster-infrastructure -q) in
+           *openais* ) nodelist=$(crm_node -l | awk '/member/ {print $2}');;    
+           *cman*    ) nodelist=$(crm_node -l);; 
+        esac
+
+        for n in ${nodelist}; do
            set_hana_attribute ${n} "$srmode" ${ATTR_NAME_HANA_SRMODE[@]}
         done
           ;;


### PR DESCRIPTION
The included commits add the ability to parse the output of "crm_node -l" based on the underlying cluster  infrastructure.
