### PR TITLE
 SAPHana: Use remoteNode instead od remoteHost for attribute queries

### DIFF
--- a/SAPHana/SAPHana
+++ b/SAPHana/SAPHana
@@ -1733,8 +1733,8 @@ function saphana_monitor_primary()
                         analyze_hana_sync_status
                         ;;
                 esac
-                rem_role=$(get_hana_attribute ${remoteHost} ${ATTR_NAME_HANA_ROLES[@]})
-                rem_clone_status=$(get_hana_attribute ${remoteHost} ${ATTR_NAME_HANA_CLONE_STATE[@]})
+                rem_role=$(get_hana_attribute ${remoteNode} ${ATTR_NAME_HANA_ROLES[@]})
+                rem_clone_status=$(get_hana_attribute ${remoteNode} ${ATTR_NAME_HANA_CLONE_STATE[@]})
                 if [ "$promote_attr" = "DEMOTED" -a "$rem_clone_status" = "PROMOTED" ]; then
                    case "$rem_role" in
                        [234]:P:* ) # dual primary, but other instance marked as PROMOTED by the cluster


### PR DESCRIPTION
Change two attribute queries to use romteNode (cluster view) and not remoteHost (hana view)
