### PR TITLE
Match the 'srmode' from $hdbANSWER more strictly as in other parts of the code

### DIFF
--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -566,7 +566,7 @@ function sht_init() {
     siteID=$(echo "$hdbANSWER" | awk -F= '/site.id/ {print $2}')       # allow 'site_id' AND 'site id'
     siteNAME=$(echo "$hdbANSWER" | awk -F= '/site.name/ {print $2}')
     site=$siteNAME
-    srmode=$(echo "$hdbANSWER" | awk -F= '/mode/ {print $2}')
+    srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
     #
     # for rev >= 111 we use the new mapping query
     #


### PR DESCRIPTION
This should prevent accidental matching of 'operational mode'
or anything else containing word 'mode' in $hdbANSWER.
Having more than one match of 'mode' word can lead to
'we didn't expect srmode to be: DUMP: ...' error later.

With HANA 2.0 SPS01 I have observed that sometimes the $hdbANSWER contains
line with 'operational mode' that caused confusion to resource agent as there were 2 lines
that contains word 'mode'. 