### PR TITLE
log outputs from HANA_CALL and report when commands in HANA_CALL times out

### DIFF
--- a/SAPHana/ra/SAPHana
+++ b/SAPHana/ra/SAPHana
@@ -634,7 +634,7 @@ function HANA_CALL()
                   fi
                   ;;
     esac
-    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$? output=$output"
+    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$rc output=$output"
     echo "$output"
     return $rc;
 }

--- a/SAPHana/ra/SAPHana
+++ b/SAPHana/ra/SAPHana
@@ -634,6 +634,7 @@ function HANA_CALL()
                   fi
                   ;;
     esac
+    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$? output=$output"
     echo "$output"
     return $rc;
 }

--- a/SAPHana/ra/SAPHana
+++ b/SAPHana/ra/SAPHana
@@ -625,6 +625,9 @@ function HANA_CALL()
                   #
                   # on timeout ...
                   #
+                  if [ $rc -eq 124 ]; then
+                      super_ocf_log warn "HANA_CALL timed out after $timeOut seconds running command '$cmd'"
+                  fi
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
                       second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -428,7 +428,7 @@ function HANA_CALL()
                   fi
                   ;;
     esac
-    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$? output=$output"
+    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$rc output=$output"
     echo "$output"
     return $rc;
 }

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -428,6 +428,7 @@ function HANA_CALL()
                   fi
                   ;;
     esac
+    super_ocf_log debug "DBG: HANA_CALL '$cmd' rc=$? output=$output"
     echo "$output"
     return $rc;
 }
@@ -550,7 +551,6 @@ function sht_init() {
             hU | * ) # call hdbnsUtil (hU) ( also for unknown chkMethod )
                 # DONE: PRIO1: Begginning from SAP HANA rev 112.03 -sr_state is not longer supported
                 hdbANSWER=$(HANA_CALL --timeout 60 --cmd "$hdbState --sapcontrol=1" 2>/dev/null)
-                super_ocf_log debug "DBG2: hdbANSWER=$hdbANSWER"
                 srmode=$(echo "$hdbANSWER" | awk -F= '$1=="mode" {print $2}')
                 ;;
         esac

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -419,6 +419,9 @@ function HANA_CALL()
                   #
                   # on timeout ...
                   #
+                  if [ $rc -eq 124 ]; then
+                      super_ocf_log warn "HANA_CALL timed out after $timeOut seconds running command '$cmd'"
+                  fi
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
                       second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");


### PR DESCRIPTION
Recently I came across case where SAP HANA calls were "most probably" timing out. However it was not clear if this was really a timeout of call or if the resource agent just spends this time elsewhere.
In overall the regular user may not be aware that something has timed out and it can blame the resource agent for not processing further requests properly.

I'm proposing here:
1. Change to log WARNING into logs when the HANA_CALL function detects that command($cmd) has timed out. 
2. When the command execution ($cmd) in HANA_CALL times out it is highly probable that we don't have all the data that might be processed further, but we also don't know what data we have managed to get so far. For that reason this request introduces logging of the $output, $rc and $cmd from HANA_CALL function into DEBUG log. Logging is done regardless of timeout setting to allow collection of the output in situation when $cmd is not timing out, but later processing in resource agent fails to parse some data. With the output from $cmd and the source code of resource agent is then possible to use the output for further troubleshooting.
This also removes the need for logging $hdbANSWER variable in SAPHanaTopology as this will be collected in HANA_CALL instead.

By default the DEBUG logging is not enabled so this will not affect the size of logs on regular setups. When DEBUG logging is enabled (via PCMK_debug=yes or PCMK_debug=lrmd) this will print into DEBUG logs the outputs from all HANA_CALL. 

Would it make sense to merge these changes?
Please let me know if any changes to this pull request are needed.