### PR TITLE
Add attribute 'ontimeout_script' to both resource agents

### DIFF
--- a/SAPHana/man/ocf_suse_SAPHana.7
+++ b/SAPHana/man/ocf_suse_SAPHana.7
@@ -152,6 +152,15 @@ The default is sufficient for normal operation.
 Optional.
 .RE
 .PP
+\fBontimeout_script\fR
+.RS 4
+(for debugging only) Script that is executed when HANA_CALL times out. Script
+will run in the same environment as the command that has timed out. Output from
+the script is logged in DEBUG logs.
+.br
+Optional.
+.RE
+.PP
 .\"
 .SH SUPPORTED ACTIONS
 .br

--- a/SAPHana/man/ocf_suse_SAPHanaTopology.7
+++ b/SAPHana/man/ocf_suse_SAPHanaTopology.7
@@ -70,6 +70,15 @@ The default is sufficient for normal operation.
 Optional.
 .RE
 .PP
+\fBontimeout_script\fR
+.RS 4
+(for debugging only) Script that is executed when HANA_CALL times out. Script
+will run in the same environment as the command that has timed out. Output from
+the script is logged in DEBUG logs.
+.br
+Optional.
+.RE
+.PP
 .\"
 .SH SUPPORTED ACTIONS
 .br

--- a/SAPHana/ra/SAPHana
+++ b/SAPHana/ra/SAPHana
@@ -30,6 +30,7 @@
 #   OCF_RESKEY_PREFER_SITE_TAKEOVER (optional, default is no)
 #   OCF_RESKEY_DUPLICATE_PRIMARY_TIMEOUT (optional, time difference needed between two last-primary-tiemstampe (lpt))
 #   OCF_RESKEY_SAPHanaFilter    (outdated, replaced by cluster property hana_${sid}_glob_filter)
+#   OCF_RESKEY_ontimeout_script (optional, for debugging only, script that is run when HANA_CALL times out)
 #
 #
 #######################################################################
@@ -251,6 +252,11 @@ The resource agent uses the following four interfaces provided by SAP:
     <parameter name="SAPHanaFilter" unique="0" required="0">
         <shortdesc lang="en">OUTDATED PARAMETER</shortdesc>
         <longdesc lang="en">OUTDATED PARAMETER</longdesc>
+        <content type="string" default="" />
+    </parameter>
+    <parameter name="ontimeout_script" unique="0" required="0">
+        <longdesc lang="en">(for debugging only) Script that is executed when HANA_CALL times out. Script will run in the same environment as the command that has timed out. Output from the script is logged in DEBUG logs.</longdesc>
+        <shortdesc lang="en">Script that is run when HANA_CALL times out.</shortdesc>
         <content type="string" default="" />
     </parameter>
 </parameters>
@@ -586,7 +592,7 @@ function HANA_CALL()
     #       root-user-called hdbnsutil -sr_state (which creates root-owned shared memory file in /var/lib/hdb/SID/shmgrp)
     # TODO: PRIO 5: Maybe make "su" optional by a parameter
     local timeOut=0
-    local onTimeOut=""
+    local onTimeOut="$OCF_RESKEY_ontimeout_script"
     local rc=0
     local use_su=1 # Default to be changed later (see TODO above)
     local pre_cmd=""
@@ -627,7 +633,9 @@ function HANA_CALL()
                   #
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
-                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                      super_ocf_log debug "DBG: HANA_CALL running ontimeout script '$onTimeOut'"
+                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut"); rc2=$?
+                      super_ocf_log debug "DBG: HANA_CALL ontimeout '$onTimeOut' rc=$rc2 output=$second_output"
                   fi
                   ;;
     esac

--- a/SAPHana/ra/SAPHanaTopology
+++ b/SAPHana/ra/SAPHanaTopology
@@ -24,6 +24,7 @@
 #   OCF_RESKEY_InstanceNumber (00..99)
 #	OCF_RESKEY_DIR_EXECUTABLE   (optional, well known directories will be searched by default)
 #   OCF_RESKEY_SAPHanaFilter    (outdated, replaced by cluster property hana_${sid}_glob_filter)
+#   OCF_RESKEY_ontimeout_script (optional, for debugging only, script that is run when HANA_CALL times out)
 #
 #######################################################################
 #
@@ -181,6 +182,11 @@ SAPHanaTopology scans the output table of landscapeHostConfiguration.py to ident
     <parameter name="SAPHanaFilter" unique="0" required="0">
         <shortdesc lang="en">OUTDATED</shortdesc>
         <longdesc lang="en">OUTDATED</longdesc>
+        <content type="string" default="" />
+    </parameter>
+    <parameter name="ontimeout_script" unique="0" required="0">
+        <longdesc lang="en">(for debugging only) Script that is executed when HANA_CALL times out. Script will run in the same environment as the command that has timed out. Output from the script is logged in DEBUG logs.</longdesc>
+        <shortdesc lang="en">Script that is run when HANA_CALL times out.</shortdesc>
         <content type="string" default="" />
     </parameter>
 </parameters>
@@ -380,7 +386,7 @@ function HANA_CALL()
     #       root-user-called hdbnsutil -sr_state (which creates root-owned shared memory file in /var/lib/hdb/SID/shmgrp)
     # TODO: PRIO 5: Maybe make "su" optional by a parameter
     local timeOut=0
-    local onTimeOut=""
+    local onTimeOut="$OCF_RESKEY_ontimeout_script"
     local rc=0
     local use_su=1 # Default to be changed later (see TODO above)
     local pre_cmd=""
@@ -421,7 +427,9 @@ function HANA_CALL()
                   #
                   if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
                       local second_output=""
-                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut");
+                      super_ocf_log debug "DBG: HANA_CALL running ontimeout script '$onTimeOut'"
+                      second_output=$($pre_cmd "$pre_script; /usr/sap/$SID/$InstanceName/HDBSettings.sh $onTimeOut"); rc2=$?
+                      super_ocf_log debug "DBG: HANA_CALL ontimeout '$onTimeOut' rc=$rc2 output=$second_output"
                   fi
                   ;;
     esac


### PR DESCRIPTION
I have noticed that both resource agents include condition that should allow execution of "onTimeOut" command when the main command in HANA_CALL times out. However from code it looks that this is never executed and there is no HANA_CALL that would pass the needed parameter to enable this functionality. I see the below code that populates the $onTimeOut variable when the HANA_CALL passes the the script after argument '--on-timeout'. However I don't see any occasion when '--on-timeout' is used in both resource agents.

~~~
local onTimeOut=""
~~~

~~~
    while [ $# -gt 0 ]; do
        case "$1" in
            --timeout ) timeOut=$2; shift;;
            --use-su  ) use_su=1;;
            --on-timeout ) onTimeOut="$2"; shift;;
            --cmd ) shift; cmd="$*"; break;;
        esac
        shift
    done
~~~

~~~
if [ $rc -eq 124 -a -n "$onTimeOut" ]; then
~~~

It may be useful to specify this command somehow to gather some data from HANA_CALL timeout happens. Therefore I have slightly edited code to allow specifying the script via resource agent attribute named 'ontimeout_script'. This attribute is optional and by default it has same (empty) value as the variable $onTimeOut had before. Once the script is specified, the resource agent will execute it when HANA_CALL $cmd has timed out. There are 2 additional commands to log 'start' of the command and 'end of command with outputs'. I have included both so it is possible to determine when this script was started - in case that operation in cluster times out, we would be able to tell thanks to that if the script was attempted to run or not.

This request contains the changes for both resource agents and changes in man pages to reflect the same texts as long description in resource agents. 

Please let me know if this makes sense or if there is a better way how to achieve running a command when the timeout of HANA_CALL cmd happens.